### PR TITLE
Implement backend Clio endpoint

### DIFF
--- a/api/clio-matters.js
+++ b/api/clio-matters.js
@@ -1,0 +1,52 @@
+export default async function handler(req, res) {
+  const { CLIO_CLIENT_ID, CLIO_CLIENT_SECRET } = process.env;
+  if (!CLIO_CLIENT_ID || !CLIO_CLIENT_SECRET) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Clio credentials not configured' }));
+    return;
+  }
+
+  try {
+    const tokenRes = await fetch('https://app.clio.com/oauth/token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'client_credentials',
+        client_id: CLIO_CLIENT_ID,
+        client_secret: CLIO_CLIENT_SECRET,
+        scope: 'read:matters',
+      }),
+    });
+
+    if (!tokenRes.ok) {
+      const text = await tokenRes.text();
+      res.statusCode = 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Failed to obtain access token', details: text }));
+      return;
+    }
+
+    const token = await tokenRes.json();
+    const mattersRes = await fetch('https://app.clio.com/api/v4/matters?states=active', {
+      headers: { Authorization: `Bearer ${token.access_token}` },
+    });
+
+    if (!mattersRes.ok) {
+      const text = await mattersRes.text();
+      res.statusCode = 500;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Failed to fetch matters', details: text }));
+      return;
+    }
+
+    const matters = await mattersRes.json();
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(matters));
+  } catch (err) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: 'Unexpected error', details: err.message }));
+  }
+}

--- a/src/components/WorkflowPage.tsx
+++ b/src/components/WorkflowPage.tsx
@@ -49,29 +49,11 @@ const WorkflowPage = ({ workflow, onBack }: WorkflowPageProps) => {
       if (workflow !== 'petition') return;
       setLoadingMatters(true);
       try {
-        const tokenRes = await fetch('https://app.clio.com/oauth/token', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            grant_type: 'client_credentials',
-            client_id: import.meta.env.VITE_CLIO_CLIENT_ID,
-            client_secret: import.meta.env.VITE_CLIO_CLIENT_SECRET,
-            scope: 'read:matters',
-          }),
-        });
-        const token = await tokenRes.json();
-        const res = await fetch(
-          'https://app.clio.com/api/v4/matters?states=active',
-          {
-            headers: {
-              Authorization: `Bearer ${token.access_token}`,
-            },
-          },
-        );
+        const res = await fetch('/api/clio-matters');
         const data = await res.json();
         setClioMatters(data?.data || []);
       } catch (err) {
-        console.error('Failed to fetch matters from Clio', err);
+        console.error('Failed to fetch matters from backend', err);
       } finally {
         setLoadingMatters(false);
       }
@@ -157,7 +139,29 @@ const WorkflowPage = ({ workflow, onBack }: WorkflowPageProps) => {
       }
 
       // Reset form
-@@ -101,58 +183,79 @@ const WorkflowPage = ({ workflow, onBack }: WorkflowPageProps) => {
+      setMatter('');
+      setNotes('');
+      setFiles(null);
+      (document.getElementById('file-upload') as HTMLInputElement).value = '';
+
+    } catch (error) {
+      console.error('Error submitting workflow:', error);
+      toast.error('Failed to submit workflow. Please try again.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen gradient-bg">
+      <header className="border-b border-slate-700 bg-slate-900/50 backdrop-blur-sm">
+        <div className="container mx-auto px-4 py-4 flex items-center">
+          <Button
+            onClick={onBack}
+            variant="ghost"
+            className="mr-4 text-white hover:bg-slate-700"
+          >
+            <ArrowLeft className="w-4 h-4 mr-2" />
             Back to Dashboard
           </Button>
           <div>
@@ -238,5 +242,65 @@ const WorkflowPage = ({ workflow, onBack }: WorkflowPageProps) => {
                     )}
                   </div>
 
+                  <div className="space-y-2">
+                    <Label htmlFor="notes" className="text-white">Additional Notes</Label>
+                    <Textarea
+                      id="notes"
+                      value={notes}
+                      onChange={(e) => setNotes(e.target.value)}
+                      className="bg-slate-800/50 border-slate-600 text-white placeholder:text-slate-400 min-h-[120px]"
+                      placeholder="Enter any additional notes, special instructions, or relevant details for this workflow..."
+                    />
+                  </div>
 
-export default WorkflowPage;
+                  <div className="space-y-2">
+                    <Label htmlFor="webhook" className="text-white">n8n Webhook URL (Optional)</Label>
+                    <Input
+                      id="webhook"
+                      value={webhookUrl}
+                      onChange={(e) => setWebhookUrl(e.target.value)}
+                      className="bg-slate-800/50 border-slate-600 text-white placeholder:text-slate-400"
+                      placeholder="Enter your n8n webhook URL for workflow automation"
+                    />
+                    <p className="text-sm text-slate-400">
+                      This URL will receive the workflow data to trigger document generation
+                    </p>
+                  </div>
+
+                  <div className="flex justify-end space-x-4">
+                    <Button
+                      type="button"
+                      onClick={onBack}
+                      variant="outline"
+                      className="border-slate-600 text-white hover:bg-slate-700"
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      type="submit"
+                      disabled={isSubmitting}
+                      className="bg-primary hover:bg-primary/90 text-white"
+                    >
+                      {isSubmitting ? 'Processing...' : 'Submit Workflow'}
+                    </Button>
+                  </div>
+                </form>
+              </CardContent>
+            </Card>
+
+            <div className="mt-6 p-4 bg-slate-800/30 rounded-lg border border-slate-700">
+              <h3 className="text-white font-medium mb-2">Next Steps:</h3>
+              <ul className="text-slate-300 text-sm space-y-1">
+                <li>• Your workflow will be processed through our automated system</li>
+                <li>• Generated documents will be available for download</li>
+                <li>• You'll receive a notification when processing is complete</li>
+                <li>• All submissions are logged for quality assurance</li>
+              </ul>
+            </div>
+          </div>
+        </main>
+      </div>
+    );
+  };
+
+  export default WorkflowPage;


### PR DESCRIPTION
## Summary
- add serverless `api/clio-matters.js` to authenticate with Clio and return active matters
- update `WorkflowPage` to fetch matters from the backend
- remove direct use of Clio secrets in the frontend

## Testing
- `npm run lint` *(fails: several existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6864b346e858832ba1da814de4034ea2